### PR TITLE
fix: add asset with correct mount name so capsule can be run stand alone

### DIFF
--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -1,0 +1,13 @@
+{
+	"version": 1,
+	"attached_datasets": [
+		{
+			"id": "a69aea3e-0813-4113-abd5-0f5707392673",
+			"mount": "fib_raw_nwb"
+		},
+		{
+			"id": "e7f73588-fea9-43df-b0df-f5a54f361395",
+			"mount": "fiber_raw_data"
+		}
+	]
+}

--- a/.codeocean/environment.json
+++ b/.codeocean/environment.json
@@ -1,0 +1,92 @@
+{
+	"version": 1,
+	"base_image": "codeocean/mambaforge3:23.1.0-4-python3.10.12-ubuntu22.04",
+	"options": {
+		"registry_host_arg": true,
+		"git_ask_pass": true,
+		"mount_secrets": true
+	},
+	"installers": {
+		"pip3": {
+			"packages": [
+				{
+					"name": "aind-data-schema",
+					"version": "1.4.0"
+				},
+				{
+					"name": "aind-metadata-upgrader",
+					"version": "0.0.26"
+				},
+				{
+					"name": "aind-qcportal-schema",
+					"version": "0.4.0"
+				},
+				{
+					"name": "hdmf-zarr",
+					"version": "0.11.3"
+				},
+				{
+					"name": "matplotlib",
+					"version": "3.10.6"
+				},
+				{
+					"name": "pynwb",
+					"version": "3.1.2"
+				},
+				{
+					"name": "pyyaml",
+					"version": "6.0.3"
+				},
+				{
+					"name": "scikit-learn",
+					"version": "1.7.2"
+				},
+				{
+					"name": "statsmodels",
+					"version": "0.14.5"
+				},
+				{
+					"name": "watchtower",
+					"version": "3.4.0"
+				}
+			],
+			"options": {},
+			"pre_install_options": {}
+		},
+		"vscode": {
+			"packages": [
+				{
+					"name": "ms-python.python",
+					"version": "2025.14.0"
+				},
+				{
+					"name": "ms-toolsai.jupyter",
+					"version": "2025.4.1"
+				},
+				{
+					"name": "reditorsupport.r",
+					"version": "2.8.6"
+				},
+				{
+					"name": "saoudrizwan.claude-dev",
+					"version": "3.35.1"
+				}
+			],
+			"version": "4.100.3"
+		}
+	},
+	"env_variables": [
+		{
+			"name": "VERSION",
+			"value": "16.0"
+		},
+		{
+			"name": "DFF_EXTRACTION_URL",
+			"value": "https://github.com/AllenNeuralDynamics/aind-fip-dff"
+		},
+		{
+			"name": "PROCESS_NAME",
+			"value": "aind-fip-dff"
+		}
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,4 @@ dmypy.json
 !.vscode/*.code-snippets
 .vscode
 
-# CodeOcean
-.codeocean/
+


### PR DESCRIPTION
This PR tries to address #81. 

Attaches this asset which was produced from the latest nwb base capsule on main: https://codeocean.allenneuraldynamics.org/data-assets/a69aea3e-0813-4113-abd5-0f5707392673/fip-nwb-base-result

Used this session: behavior_700708_2024-06-13_09-06-26

Not sure if I overstepped, but I removed the .codeocean from the gitignore to allow the `datasets.json` file to be committed which contains the mount name.

Running a reproducible run produces all of the output files - the qc folder and the updated nwb along with the metadata files:

<img width="345" height="351" alt="{1C29F2CE-06F1-4389-8C6A-ABC284BC44EC}" src="https://github.com/user-attachments/assets/a9fc3a76-59bd-4da7-bf7f-3f290c773a7d" />
